### PR TITLE
Update README.md - fix one grammar mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Here are some tips for using LLMTime:
 - The recently released `gpt-3.5-turbo-instruct` seems to require a lower temperature (e.g. 0.3) than other models, and tends to not outperform `text-davinci-003` from our limited experiments.
 - Tuning hyperparameters based on validation likelihoods, as done by `get_autotuned_predictions_data`, will often yield better test likelihoods, but won't necessarily yield better samples. 
 
-## 📊 Replicating experiments in paper
+## 📊 Replicating experiments on paper
 Run the following commands to replicate the experiments in the paper. The outputs will be saved in `./outputs/`. You can use `visualize.ipynb` to visualize the results. We also provide precomputed outputs used in the paper in `./precomputed_outputs/`.
 ### Darts (Section 4)
 ```


### PR DESCRIPTION
I have noticed one grammatical mistake in **README** inside section "**Replicating experiments in paper**"

"**Replicating experiments in paper**"  should be "**Replicating experiments on paper**"  (Heading)


Screenshot-

![Screenshot (137)](https://github.com/ngruver/llmtime/assets/115995339/4a0bf29f-1749-4ef2-9a37-0337f322e850)
